### PR TITLE
Fix Typo in Readme Custom Conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ public class IfEnemyCondition : ICondition
 {
     public string Name { get; } = "If Enemy";
     
-    public bool IsValid(ICondition ctx)
+    public bool IsValid(IContext ctx)
     {
         if(ctx is MyContext c)
         {


### PR DESCRIPTION
Change IConditional to IContext in the IsValid function signature in the Readme. 
