### PR TITLE
Fixed issue where MTR [0,0,1] wouldn't beat LastMTR [0,1,0] during a …

### DIFF
--- a/Fluid-HTN.UnitTests/SelectorTests.cs
+++ b/Fluid-HTN.UnitTests/SelectorTests.cs
@@ -289,5 +289,36 @@ namespace Fluid_HTN.UnitTests
             Assert.IsTrue(ctx.MethodTraversalRecord.Count == 1);
             Assert.IsTrue(ctx.MethodTraversalRecord[0] == -1);
         }
+
+        [TestMethod]
+        public void DecomposeCompoundSubtaskWinOverLastMTR_ExpectedBehavior()
+        {
+            var ctx = new MyContext();
+            var rootTask = new Selector() { Name = "Root" };
+            var task = new Selector() { Name = "Test1" };
+            var task2 = new Selector() { Name = "Test2" };
+            var task3 = new Selector() {Name = "Test3"};
+
+            task3.AddSubtask(new PrimitiveTask() { Name = "Sub-task3-1" }.AddCondition(new FuncCondition<MyContext>("Done == true", context => context.Done == true)));
+            task3.AddSubtask(new PrimitiveTask() { Name = "Sub-task3-2" });
+
+            task2.AddSubtask(new PrimitiveTask() { Name = "Sub-task2-1" }.AddCondition(new FuncCondition<MyContext>("Done == true", context => context.Done == true)));
+            task2.AddSubtask(new PrimitiveTask() { Name = "Sub-task2-2" });
+
+            task.AddSubtask(task2);
+            task.AddSubtask(task3);
+            task.AddSubtask(new PrimitiveTask() { Name = "Sub-task1-1" }.AddCondition(new FuncCondition<MyContext>("Done == false", context => context.Done == false)));
+
+            rootTask.AddSubtask(task);
+
+            ctx.LastMTR.Add(0);
+            ctx.LastMTR.Add(1);
+            ctx.LastMTR.Add(0);
+
+            // In this test, we prove that [0, 0, 1] beats [0, 1, 0]
+            var status = rootTask.Decompose(ctx, 0, out var plan);
+
+            Assert.IsTrue(status == DecompositionStatus.Succeeded);
+        }
     }
 }


### PR DESCRIPTION
…re-plan.

# Pull Request

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (https://github.com/ptrefall/fluid-hierarchical-task-network/issues/8)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Created unit test to reproduce the reported issue.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules