### PR TITLE
Remove unused variable from SelectorTest

### DIFF
--- a/Fluid-HTN.UnitTests/SelectorTests.cs
+++ b/Fluid-HTN.UnitTests/SelectorTests.cs
@@ -328,7 +328,6 @@ namespace Fluid_HTN.UnitTests
             var rootTask = new Selector() { Name = "Root" };
             var task = new Selector() { Name = "Test1" };
             var task2 = new Selector() { Name = "Test2" };
-            var task3 = new Selector() { Name = "Test3" };
 
             task2.AddSubtask(new PrimitiveTask() { Name = "Sub-task2-1" }.AddCondition(new FuncCondition<MyContext>("Done == true", context => context.Done == true)));
             task2.AddSubtask(new PrimitiveTask() { Name = "Sub-task2-1" });


### PR DESCRIPTION
As far as I can tell, task3 is never used by this test and isn't necessary to the test and can be safely removed, I believe?

# Pull Request Template

## Description

This is a minor fix to address an unused variable in a test. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I eyeballed it. I found it while translating the test to JS and my linter complained.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules