### PR TITLE
Improved code complexity of Domain's FindPlan and Planner's Tick.

### DIFF
--- a/Fluid-HTN/Domain.cs
+++ b/Fluid-HTN/Domain.cs
@@ -89,64 +89,143 @@ namespace FluidHTN
             // the running partial plan.
             if (ctx.HasPausedPartialPlan && ctx.LastMTR.Count == 0)
             {
-                ctx.HasPausedPartialPlan = false;
-                while (ctx.PartialPlanQueue.Count > 0)
-                {
-                    var kvp = ctx.PartialPlanQueue.Dequeue();
-                    if (plan == null)
-                    {
-                        status = kvp.Task.Decompose(ctx, kvp.TaskIndex, out plan);
-                    }
-                    else
-                    {
-                        status = kvp.Task.Decompose(ctx, kvp.TaskIndex, out var p);
-                        if (status == DecompositionStatus.Succeeded || status == DecompositionStatus.Partial)
-                        {
-                            while (p.Count > 0)
-                            {
-                                plan.Enqueue(p.Dequeue());
-                            }
-                        }
-                    }
-
-                    // While continuing a partial plan, we might encounter
-                    // a new pause.
-                    if (ctx.HasPausedPartialPlan)
-                    {
-                        break;
-                    }
-                }
-
-                // If we failed to continue the paused partial plan,
-                // then we have to start planning from the root.
-                if (status == DecompositionStatus.Rejected || status == DecompositionStatus.Failed)
-                {
-                    ctx.MethodTraversalRecord.Clear();
-
-                    if (ctx.DebugMTR)
-                    {
-                        ctx.MTRDebug.Clear();
-                    }
-
-                    status = Root.Decompose(ctx, 0, out plan);
-                }
+                status = OnPausedPartialPlan(ctx, ref plan, status);
             }
             else
             {
-                Queue<PartialPlanEntry> lastPartialPlanQueue = null;
+                status = OnReplanDuringPartialPlanning(ctx, ref plan, status);
+            }
 
-                if (ctx.HasPausedPartialPlan)
+            // If this MTR equals the last MTR, then we need to double-check whether we ended up
+            // just finding the exact same plan. During decomposition each compound task can't check
+            // for equality, only for less than, so this case needs to be treated after the fact.
+            if (DoubleCheckMtrEquality(ctx))
+            {
+                plan = null;
+                status = DecompositionStatus.Rejected;
+            }
+
+            if (status == DecompositionStatus.Succeeded || status == DecompositionStatus.Partial)
+            {
+                // Apply permanent world state changes to the actual world state used during plan execution.
+                ApplyPermanentWorldStateStackChanges(ctx);
+            }
+            else
+            {
+                // Clear away any changes that might have been applied to the stack
+                // No changes should be made or tracked further when the plan failed.
+                ClearWorldStateStackChanges(ctx);
+            }
+
+            ctx.ContextState = ContextState.Executing;
+            return status;
+        }
+
+        /// <summary>
+        /// We first check whether we have a stored start task. This is true
+        /// if we had a partial plan pause somewhere in our plan, and we now
+        /// want to continue where we left off.
+        /// If this is the case, we don't erase the MTR, but continue building it.
+        /// However, if we have a partial plan, but LastMTR is not 0, that means
+        /// that the partial plan is still running, but something triggered a replan.
+        /// When this happens, we have to plan from the domain root (we're not
+        /// continuing the current plan), so that we're open for other plans to replace
+        /// the running partial plan.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="plan"></param>
+        /// <param name="status"></param>
+        /// <returns></returns>
+        private DecompositionStatus OnReplanDuringPartialPlanning(T ctx, ref Queue<ITask> plan, DecompositionStatus status)
+        {
+            Queue<PartialPlanEntry> lastPartialPlanQueue = null;
+
+            if (ctx.HasPausedPartialPlan)
+            {
+                ctx.HasPausedPartialPlan = false;
+                lastPartialPlanQueue = ctx.Factory.CreateQueue<PartialPlanEntry>();
+
+                while (ctx.PartialPlanQueue.Count > 0)
                 {
-                    ctx.HasPausedPartialPlan = false;
-                    lastPartialPlanQueue = ctx.Factory.CreateQueue<PartialPlanEntry>();
+                    lastPartialPlanQueue.Enqueue(ctx.PartialPlanQueue.Dequeue());
+                }
+            }
 
-                    while (ctx.PartialPlanQueue.Count > 0)
+            // We only erase the MTR if we start from the root task of the domain.
+            ctx.MethodTraversalRecord.Clear();
+
+            if (ctx.DebugMTR)
+            {
+                ctx.MTRDebug.Clear();
+            }
+
+            status = Root.Decompose(ctx, 0, out plan);
+
+            // If we failed to find a new plan, we have to restore the old plan,
+            // if it was a partial plan.
+            if (lastPartialPlanQueue != null)
+            {
+                if (status == DecompositionStatus.Rejected || status == DecompositionStatus.Failed)
+                {
+                    ctx.HasPausedPartialPlan = true;
+                    ctx.PartialPlanQueue.Clear();
+
+                    while (lastPartialPlanQueue.Count > 0)
                     {
-                        lastPartialPlanQueue.Enqueue(ctx.PartialPlanQueue.Dequeue());
+                        ctx.PartialPlanQueue.Enqueue(lastPartialPlanQueue.Dequeue());
+                    }
+
+                    ctx.Factory.FreeQueue(ref lastPartialPlanQueue);
+                }
+            }
+
+            return status;
+        }
+        
+        /// <summary>
+        /// We first check whether we have a stored start task. This is true
+        /// if we had a partial plan pause somewhere in our plan, and we now
+        /// want to continue where we left off.
+        /// If this is the case, we don't erase the MTR, but continue building it.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="plan"></param>
+        /// <param name="status"></param>
+        /// <returns></returns>
+        private DecompositionStatus OnPausedPartialPlan(T ctx, ref Queue<ITask> plan, DecompositionStatus status)
+        {
+            ctx.HasPausedPartialPlan = false;
+            while (ctx.PartialPlanQueue.Count > 0)
+            {
+                var kvp = ctx.PartialPlanQueue.Dequeue();
+                if (plan == null)
+                {
+                    status = kvp.Task.Decompose(ctx, kvp.TaskIndex, out plan);
+                }
+                else
+                {
+                    status = kvp.Task.Decompose(ctx, kvp.TaskIndex, out var p);
+                    if (status == DecompositionStatus.Succeeded || status == DecompositionStatus.Partial)
+                    {
+                        while (p.Count > 0)
+                        {
+                            plan.Enqueue(p.Dequeue());
+                        }
                     }
                 }
 
-                // We only erase the MTR if we start from the root task of the domain.
+                // While continuing a partial plan, we might encounter
+                // a new pause.
+                if (ctx.HasPausedPartialPlan)
+                {
+                    break;
+                }
+            }
+
+            // If we failed to continue the paused partial plan,
+            // then we have to start planning from the root.
+            if (status == DecompositionStatus.Rejected || status == DecompositionStatus.Failed)
+            {
                 ctx.MethodTraversalRecord.Clear();
 
                 if (ctx.DebugMTR)
@@ -155,29 +234,21 @@ namespace FluidHTN
                 }
 
                 status = Root.Decompose(ctx, 0, out plan);
-
-                // If we failed to find a new plan, we have to restore the old plan,
-                // if it was a partial plan.
-                if (lastPartialPlanQueue != null)
-                {
-                    if (status == DecompositionStatus.Rejected || status == DecompositionStatus.Failed)
-                    {
-                        ctx.HasPausedPartialPlan = true;
-                        ctx.PartialPlanQueue.Clear();
-
-                        while (lastPartialPlanQueue.Count > 0)
-                        {
-                            ctx.PartialPlanQueue.Enqueue(lastPartialPlanQueue.Dequeue());
-                        }
-
-                        ctx.Factory.FreeQueue(ref lastPartialPlanQueue);
-                    }
-                }
             }
 
-            // If this MTR equals the last MTR, then we need to double check whether we ended up
-            // just finding the exact same plan. During decomposition each compound task can't check
-            // for equality, only for less than, so this case needs to be treated after the fact.
+            return status;
+        }
+    
+
+        /// <summary>
+        /// If this MTR equals the last MTR, then we need to double-check whether we ended up
+        /// just finding the exact same plan. During decomposition each compound task can't check
+        /// for equality, only for less than, so this case needs to be treated after the fact.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <returns></returns>
+        private bool DoubleCheckMtrEquality(T ctx)
+        {
             var isMTRsEqual = ctx.MethodTraversalRecord.Count == ctx.LastMTR.Count;
             if (isMTRsEqual)
             {
@@ -190,47 +261,46 @@ namespace FluidHTN
                     }
                 }
 
-                if (isMTRsEqual)
-                {
-                    plan = null;
-                    status = DecompositionStatus.Rejected;
-                }
+                return isMTRsEqual;
             }
 
-            if (status == DecompositionStatus.Succeeded || status == DecompositionStatus.Partial)
+            return false;
+        }
+
+        /// <summary>
+        /// Apply permanent world state changes to the actual world state used during plan execution.
+        /// </summary>
+        /// <param name="ctx"></param>
+        private void ApplyPermanentWorldStateStackChanges(T ctx)
+        {
+            // Trim away any plan-only or plan&execute effects from the world state change stack, that only
+            // permanent effects on the world state remains now that the planning is done.
+            ctx.TrimForExecution();
+            
+            for (int i = 0; i < ctx.WorldStateChangeStack.Length; i++)
             {
-                // Trim away any plan-only or plan&execute effects from the world state change stack, that only
-                // permanent effects on the world state remains now that the planning is done.
-                ctx.TrimForExecution();
-
-                // Apply permanent world state changes to the actual world state used during plan execution.
-                for (var i = 0; i < ctx.WorldStateChangeStack.Length; i++)
+                var stack = ctx.WorldStateChangeStack[i];
+                if (stack != null && stack.Count > 0)
                 {
-                    var stack = ctx.WorldStateChangeStack[i];
-                    if (stack != null && stack.Count > 0)
-                    {
-                        ctx.WorldState[i] = stack.Peek().Value;
-                        stack.Clear();
-                    }
+                    ctx.WorldState[i] = stack.Peek().Value;
+                    stack.Clear();
                 }
             }
-            else
+        }
+
+        /// <summary>
+        /// Clear away any changes that might have been applied to the stack
+        /// </summary>
+        /// <param name="ctx"></param>
+        private void ClearWorldStateStackChanges(T ctx)
+        {
+            foreach (var stack in ctx.WorldStateChangeStack)
             {
-                // Clear away any changes that might have been applied to the stack
-                // No changes should be made or tracked further when the plan failed.
-                for (var i = 0; i < ctx.WorldStateChangeStack.Length; i++)
+                if (stack != null && stack.Count > 0)
                 {
-                    var stack = ctx.WorldStateChangeStack[i];
-
-                    if (stack != null && stack.Count > 0)
-                    {
-                        stack.Clear();
-                    }
+                    stack.Clear();
                 }
             }
-
-            ctx.ContextState = ContextState.Executing;
-            return status;
         }
 
         // ========================================================= SLOTS


### PR DESCRIPTION
# Improved Method Complexity

## Description

I decided to break up FindPlan of Domain and Tick of Planner into smaller functions, to ease the complexity a bit. Hopefully should make the code easier to follow and make it easier to make custom modifications too.

## Type of change

- [x] Code cleanup

## How Has This Been Tested?

- [x] All unit tests still pass

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules