### PR TITLE
Stateless Planner

### DIFF
--- a/Fluid-HTN.UnitTests/MyContext.cs
+++ b/Fluid-HTN.UnitTests/MyContext.cs
@@ -15,7 +15,8 @@ public enum MyWorldState : byte
 internal class MyContext : BaseContext
 {
     private byte[] _worldState = new byte[Enum.GetValues(typeof(MyWorldState)).Length];
-    public override IFactory Factory { get; set; } = new DefaultFactory();
+    public override IFactory Factory { get; protected set; } = new DefaultFactory();
+    public override IPlannerState PlannerState { get; protected set; } = new DefaultPlannerState();
     public override List<string> MTRDebug { get; set; } = null;
     public override List<string> LastMTRDebug { get; set; } = null;
     public override bool DebugMTR { get; } = false;

--- a/Fluid-HTN.UnitTests/PlannerTests.cs
+++ b/Fluid-HTN.UnitTests/PlannerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using FluidHTN;
 using FluidHTN.Compounds;
 using FluidHTN.Conditions;
@@ -13,25 +14,6 @@ namespace Fluid_HTN.UnitTests
     [TestClass]
     public class PlannerTests
     {
-        [TestMethod]
-        public void GetPlanReturnsClearInstanceAtStart_ExpectedBehavior()
-        {
-            var planner = new Planner<MyContext>();
-            var plan = planner.GetPlan();
-
-            Assert.IsTrue(plan != null);
-            Assert.IsTrue(plan.Count == 0);
-        }
-
-        [TestMethod]
-        public void GetCurrentTaskReturnsNullAtStart_ExpectedBehavior()
-        {
-            var planner = new Planner<MyContext>();
-            var task = planner.GetCurrentTask();
-
-            Assert.IsTrue(task == null);
-        }
-
         [TestMethod]
         [ExpectedException(typeof(NullReferenceException), AllowDerivedTypes = false)]
         public void TickWithNullParametersThrowsNRE_ExpectedBehavior()
@@ -82,10 +64,9 @@ namespace Fluid_HTN.UnitTests
             domain.Add(task1, task2);
 
             planner.Tick(domain, ctx);
-            var currentTask = planner.GetCurrentTask();
 
-            Assert.IsTrue(currentTask == null);
-            Assert.IsTrue(planner.LastStatus == TaskStatus.Failure);
+            Assert.IsTrue(ctx.PlannerState.CurrentTask == null);
+            Assert.IsTrue(ctx.PlannerState.LastStatus == TaskStatus.Failure);
         }
 
         [TestMethod]
@@ -102,10 +83,9 @@ namespace Fluid_HTN.UnitTests
             domain.Add(task1, task2);
 
             planner.Tick(domain, ctx);
-            var currentTask = planner.GetCurrentTask();
 
-            Assert.IsTrue(currentTask == null);
-            Assert.IsTrue(planner.LastStatus == TaskStatus.Failure);
+            Assert.IsTrue(ctx.PlannerState.CurrentTask == null);
+            Assert.IsTrue(ctx.PlannerState.LastStatus == TaskStatus.Failure);
         }
 
         [TestMethod]
@@ -122,10 +102,9 @@ namespace Fluid_HTN.UnitTests
             domain.Add(task1, task2);
 
             planner.Tick(domain, ctx);
-            var currentTask = planner.GetCurrentTask();
 
-            Assert.IsTrue(currentTask == null);
-            Assert.IsTrue(planner.LastStatus == TaskStatus.Success);
+            Assert.IsTrue(ctx.PlannerState.CurrentTask == null);
+            Assert.IsTrue(ctx.PlannerState.LastStatus == TaskStatus.Success);
         }
 
         [TestMethod]
@@ -142,10 +121,9 @@ namespace Fluid_HTN.UnitTests
             domain.Add(task1, task2);
 
             planner.Tick(domain, ctx);
-            var currentTask = planner.GetCurrentTask();
 
-            Assert.IsTrue(currentTask != null);
-            Assert.IsTrue(planner.LastStatus == TaskStatus.Continue);
+            Assert.IsTrue(ctx.PlannerState.CurrentTask != null);
+            Assert.IsTrue(ctx.PlannerState.LastStatus == TaskStatus.Continue);
         }
 
         [TestMethod]
@@ -155,7 +133,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnNewPlan = (p) => { test = p.Count == 1; };
+            ctx.PlannerState.OnNewPlan = (p) => { test = p.Count == 1; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test" };
             var task2 = new PrimitiveTask() { Name = "Sub-task" };
@@ -175,7 +153,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnReplacePlan = (op, ct, p) => { test = op.Count == 0 && ct != null && p.Count == 1; };
+            ctx.PlannerState.OnReplacePlan = (op, ct, p) => { test = op.Count == 0 && ct != null && p.Count == 1; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test1" };
             var task2 = new Selector() { Name = "Test2" };
@@ -205,7 +183,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnNewTask = (t) => { test = t.Name == "Sub-task"; };
+            ctx.PlannerState.OnNewTask = (t) => { test = t.Name == "Sub-task"; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test" };
             var task2 = new PrimitiveTask() { Name = "Sub-task" };
@@ -225,7 +203,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnNewTaskConditionFailed = (t, c) => { test = t.Name == "Sub-task1"; };
+            ctx.PlannerState.OnNewTaskConditionFailed = (t, c) => { test = t.Name == "Sub-task1"; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test1" };
             var task2 = new Selector() { Name = "Test2" };
@@ -260,7 +238,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnStopCurrentTask = (t) => { test = t.Name == "Sub-task2"; };
+            ctx.PlannerState.OnStopCurrentTask = (t) => { test = t.Name == "Sub-task2"; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test1" };
             var task2 = new Selector() { Name = "Test2" };
@@ -290,7 +268,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnCurrentTaskCompletedSuccessfully = (t) => { test = t.Name == "Sub-task1"; };
+            ctx.PlannerState.OnCurrentTaskCompletedSuccessfully = (t) => { test = t.Name == "Sub-task1"; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test1" };
             var task2 = new Selector() { Name = "Test2" };
@@ -320,7 +298,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnApplyEffect = (e) => { test = e.Name == "TestEffect"; };
+            ctx.PlannerState.OnApplyEffect = (e) => { test = e.Name == "TestEffect"; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test1" };
             var task2 = new Selector() { Name = "Test2" };
@@ -352,7 +330,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnCurrentTaskFailed = (t) => { test = t.Name == "Sub-task"; };
+            ctx.PlannerState.OnCurrentTaskFailed = (t) => { test = t.Name == "Sub-task"; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test" };
             var task2 = new PrimitiveTask() { Name = "Sub-task" };
@@ -372,7 +350,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnCurrentTaskContinues = (t) => { test = t.Name == "Sub-task"; };
+            ctx.PlannerState.OnCurrentTaskContinues = (t) => { test = t.Name == "Sub-task"; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test" };
             var task2 = new PrimitiveTask() { Name = "Sub-task" };
@@ -392,7 +370,7 @@ namespace Fluid_HTN.UnitTests
             var ctx = new MyContext();
             ctx.Init();
             var planner = new Planner<MyContext>();
-            planner.OnCurrentTaskExecutingConditionFailed = (t, c) => { test = t.Name == "Sub-task" && c.Name == "TestCondition"; };
+            ctx.PlannerState.OnCurrentTaskExecutingConditionFailed = (t, c) => { test = t.Name == "Sub-task" && c.Name == "TestCondition"; };
             var domain = new Domain<MyContext>("Test");
             var task1 = new Selector() { Name = "Test" };
             var task2 = new PrimitiveTask() { Name = "Sub-task" };
@@ -433,8 +411,8 @@ namespace Fluid_HTN.UnitTests
             ITask currentTask;
 
             planner.Tick(domain, ctx, false);
-            plan = planner.GetPlan();
-            currentTask = planner.GetCurrentTask();
+            plan = ctx.PlannerState.Plan;
+            currentTask = ctx.PlannerState.CurrentTask;
             Assert.IsTrue(plan != null);
             Assert.IsTrue(plan.Count == 0);
             Assert.IsTrue(currentTask.Name == "Test Action B");
@@ -446,8 +424,8 @@ namespace Fluid_HTN.UnitTests
             ctx.Done = true;
 
             planner.Tick(domain, ctx, true);
-            plan = planner.GetPlan();
-            currentTask = planner.GetCurrentTask();
+            plan = ctx.PlannerState.Plan;
+            currentTask = ctx.PlannerState.CurrentTask;
             Assert.IsTrue(plan != null);
             Assert.IsTrue(plan.Count == 0);
             Assert.IsTrue(currentTask.Name == "Test Action A");
@@ -481,8 +459,8 @@ namespace Fluid_HTN.UnitTests
             ITask currentTask;
 
             planner.Tick(domain, ctx, false);
-            plan = planner.GetPlan();
-            currentTask = planner.GetCurrentTask();
+            plan = ctx.PlannerState.Plan;
+            currentTask = ctx.PlannerState.CurrentTask;
             Assert.IsTrue(plan != null);
             Assert.IsTrue(plan.Count == 0);
             Assert.IsTrue(currentTask.Name == "Test Action B");
@@ -494,8 +472,8 @@ namespace Fluid_HTN.UnitTests
             ctx.SetState(MyWorldState.HasA, true, EffectType.Permanent);
 
             planner.Tick(domain, ctx, true);
-            plan = planner.GetPlan();
-            currentTask = planner.GetCurrentTask();
+            plan = ctx.PlannerState.Plan;
+            currentTask = ctx.PlannerState.CurrentTask;
             Assert.IsTrue(plan != null);
             Assert.IsTrue(plan.Count == 0);
             Assert.IsTrue(currentTask.Name == "Test Action A");
@@ -531,8 +509,8 @@ namespace Fluid_HTN.UnitTests
             ITask currentTask;
 
             planner.Tick(domain, ctx, false);
-            plan = planner.GetPlan();
-            currentTask = planner.GetCurrentTask();
+            plan = ctx.PlannerState.Plan;
+            currentTask = ctx.PlannerState.CurrentTask;
             Assert.IsTrue(plan != null);
             Assert.IsTrue(plan.Count == 0);
             Assert.IsTrue(currentTask.Name == "Test Action A");
@@ -544,8 +522,8 @@ namespace Fluid_HTN.UnitTests
             ctx.SetState(MyWorldState.HasA, true, EffectType.Permanent);
 
             planner.Tick(domain, ctx, true);
-            plan = planner.GetPlan();
-            currentTask = planner.GetCurrentTask();
+            plan = ctx.PlannerState.Plan;
+            currentTask = ctx.PlannerState.CurrentTask;
             Assert.IsTrue(plan != null);
             Assert.IsTrue(plan.Count == 0);
             Assert.IsTrue(currentTask.Name == "Test Action B");

--- a/Fluid-HTN/Contexts/BaseContext.cs
+++ b/Fluid-HTN/Contexts/BaseContext.cs
@@ -14,7 +14,8 @@ namespace FluidHTN.Contexts
         public bool IsDirty { get; set; }
         public ContextState ContextState { get; set; } = ContextState.Executing;
         public int CurrentDecompositionDepth { get; set; } = 0;
-        public abstract IFactory Factory { get; set; }
+        public abstract IFactory Factory { get; protected set; }
+        public abstract IPlannerState PlannerState { get; protected set; }
         public List<int> MethodTraversalRecord { get; set; } = new List<int>();
         public List<int> LastMTR { get; } = new List<int>();
         public abstract List<string> MTRDebug { get; set; }

--- a/Fluid-HTN/Contexts/IContext.cs
+++ b/Fluid-HTN/Contexts/IContext.cs
@@ -29,7 +29,9 @@ namespace FluidHTN
         ContextState ContextState { get; set; }
         int CurrentDecompositionDepth { get; set; }
 
-        IFactory Factory { get; set; }
+        IFactory Factory { get; }
+
+        IPlannerState PlannerState { get; }
 
         /// <summary>
         ///     The Method Traversal Record is used while decomposing a domain and

--- a/Fluid-HTN/Fluid-HTN.csproj
+++ b/Fluid-HTN/Fluid-HTN.csproj
@@ -49,6 +49,8 @@
     <Compile Include="Factory\DefaultFactory.cs" />
     <Compile Include="Factory\IFactory.cs" />
     <Compile Include="IDomain.cs" />
+    <Compile Include="Planners\DefaultPlannerState.cs" />
+    <Compile Include="Planners\IPlannerState.cs" />
     <Compile Include="Tasks\CompoundTasks\DecompositionStatus.cs" />
     <Compile Include="Tasks\CompoundTasks\IDecomposeAll.cs" />
     <Compile Include="Tasks\CompoundTasks\PausePlanTask.cs" />

--- a/Fluid-HTN/Planners/DefaultPlannerState.cs
+++ b/Fluid-HTN/Planners/DefaultPlannerState.cs
@@ -1,0 +1,29 @@
+﻿using FluidHTN.Conditions;
+using FluidHTN.PrimitiveTasks;
+using System;
+using System.Collections.Generic;
+
+namespace FluidHTN
+{
+    public class DefaultPlannerState : IPlannerState
+    {
+        // ========================================================= PROPERTIES
+
+        public ITask CurrentTask { get; set; }
+        public Queue<ITask> Plan { get; set; } = new Queue<ITask>();
+        public TaskStatus LastStatus { get; set; }
+
+        // ========================================================= CALLBACKS
+
+        public Action<Queue<ITask>> OnNewPlan { get; set; }
+        public Action<Queue<ITask>, ITask, Queue<ITask>> OnReplacePlan { get; set; }
+        public Action<ITask> OnNewTask { get; set; }
+        public Action<ITask, ICondition> OnNewTaskConditionFailed { get; set; }
+        public Action<IPrimitiveTask> OnStopCurrentTask { get; set; }
+        public Action<IPrimitiveTask> OnCurrentTaskCompletedSuccessfully { get; set; }
+        public Action<IEffect> OnApplyEffect { get; set; }
+        public Action<IPrimitiveTask> OnCurrentTaskFailed { get; set; }
+        public Action<IPrimitiveTask> OnCurrentTaskContinues { get; set; }
+        public Action<IPrimitiveTask, ICondition> OnCurrentTaskExecutingConditionFailed { get; set; }
+    }
+}

--- a/Fluid-HTN/Planners/IPlannerState.cs
+++ b/Fluid-HTN/Planners/IPlannerState.cs
@@ -1,0 +1,76 @@
+﻿using FluidHTN.Conditions;
+using FluidHTN.PrimitiveTasks;
+using System;
+using System.Collections.Generic;
+
+namespace FluidHTN
+{
+    public interface IPlannerState
+    {
+        // ========================================================= PROPERTIES
+
+        ITask CurrentTask { get; set; }
+        Queue<ITask> Plan { get; set; }
+        TaskStatus LastStatus { get; set; }
+
+        // ========================================================= CALLBACKS
+
+        /// <summary>
+        ///		OnNewPlan(newPlan) is called when we found a new plan, and there is no
+        ///		old plan to replace.
+        /// </summary>
+        Action<Queue<ITask>> OnNewPlan { get; set; }
+
+        /// <summary>
+        ///		OnReplacePlan(oldPlan, currentTask, newPlan) is called when we're about to replace the
+        ///		current plan with a new plan.
+        /// </summary>
+        Action<Queue<ITask>, ITask, Queue<ITask>> OnReplacePlan { get; set; }
+
+        /// <summary>
+        ///		OnNewTask(task) is called after we popped a new task off the current plan.
+        /// </summary>
+        Action<ITask> OnNewTask { get; set; }
+
+        /// <summary>
+        ///		OnNewTaskConditionFailed(task, failedCondition) is called when we failed to
+        ///		validate a condition on a new task.
+        /// </summary>
+        Action<ITask, ICondition> OnNewTaskConditionFailed { get; set; }
+
+        /// <summary>
+        ///		OnStopCurrentTask(task) is called when the currently running task was stopped
+        ///		forcefully.
+        /// </summary>
+        Action<IPrimitiveTask> OnStopCurrentTask { get; set; }
+
+        /// <summary>
+        ///		OnCurrentTaskCompletedSuccessfully(task) is called when the currently running task
+        ///		completes successfully, and before its effects are applied.
+        /// </summary>
+        Action<IPrimitiveTask> OnCurrentTaskCompletedSuccessfully { get; set; }
+
+        /// <summary>
+        ///		OnApplyEffect(effect) is called for each effect of the type PlanAndExecute on a
+        ///		completed task.
+        /// </summary>
+        Action<IEffect> OnApplyEffect { get; set; }
+
+        /// <summary>
+        ///		OnCurrentTaskFailed(task) is called when the currently running task fails to complete.
+        /// </summary>
+        Action<IPrimitiveTask> OnCurrentTaskFailed { get; set; }
+
+        /// <summary>
+        ///		OnCurrentTaskContinues(task) is called every tick that a currently running task
+        ///		needs to continue.
+        /// </summary>
+        Action<IPrimitiveTask> OnCurrentTaskContinues { get; set; }
+
+        /// <summary>
+        ///		OnCurrentTaskExecutingConditionFailed(task, condition) is called if an Executing Condition
+        ///		fails. The Executing Conditions are checked before every call to task.Operator.Update(...).
+        /// </summary>
+        Action<IPrimitiveTask, ICondition> OnCurrentTaskExecutingConditionFailed { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A simple HTN planner based around the principles of the Builder pattern, inspire
 * Uses a Factory interface internally to create and free arrays/collections/objects, allowing the user to add pooling, or other memory management schemes.
 * Decomposition logging, for debugging.
 * Comes with Unity Package Module definitions for seamless integration into Unity projects.
-* 150 unit tests.
+* 148 unit tests.
 
 ## Support
 Join the [discord channel](https://discord.gg/MuccnAz) to share your experience and get support on the usage of Fluid HTN.
@@ -75,7 +75,8 @@ public class MyContext : BaseContext
     public override Queue<IBaseDecompositionLogEntry> DecompositionLog { get; set; } = null;
     public override bool LogDecomposition { get; } = false;
     
-    public override IFactory Factory { get; set; } = new DefaultFactory();
+    public override IFactory Factory { get; protected set; } = new DefaultFactory();
+    public override IPlannerState PlannerState { get; protected set; } = new DefaultPlannerState();
     private byte[] _worldState = new byte[Enum.GetValues(typeof(MyWorldState)).Length];
     public override byte[] WorldState => _worldState;
     
@@ -571,7 +572,7 @@ foreach(var log in ctx.LastMTRDebug)
 ```
 The reason these debug properties are all abstract in BaseContext, is because Fluid HTN must be generic enough to be used varied environments. In Unity, for instance, a user might want to have these debug flags enabled only when in the editor, or when running the game in a special dev-mode. Or maybe the user doesn't use Unity at all, and other policies are applied for when to debug.
 #### Callback hooks in the planner
-Sometimes these debug logs won't be enough to understand how the planner flows and gives us the results it does. Or maybe there is a need to hook up to certain events in the planner for other purposes. The planner exposes multiple callbacks that we can hook up to.
+Sometimes these debug logs won't be enough to understand how the planner flows and gives us the results it does. Or maybe there is a need to hook up to certain events in the planner for other purposes. The planner state exposes multiple callbacks that we can hook up to.
 
 OnNewPlan(newPlan) is called when we found a new plan, and there is no old plan to replace.
 ```C#


### PR DESCRIPTION
Added IPlannerState and DefaultPlannerState that holds all state that used to be owned by Planner. IContext holds the PlannerState. This makes it easier to multi-thread the use of Fluid HTN and use it with Unity DOTS, for instance.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] PlannerTests was updated and all tests pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules